### PR TITLE
Added initial calibration for Ambu SPUR II bag

### DIFF
--- a/ApolloBVM/src/panel.h
+++ b/ApolloBVM/src/panel.h
@@ -82,7 +82,7 @@ class EditPanel : public Panel {
     int _delta_exhale = 1;
 
     int _min_tidal_volume = 300;
-    int _max_tidal_volume = 650;
+    int _max_tidal_volume = 700;
     int _delta_tidal_volume = 50;
 
     int _row = 0;

--- a/master/master.ino
+++ b/master/master.ino
@@ -8,6 +8,9 @@ Encoder enc(5,6);
 ButtonManager encoder_button(7, true);
 ButtonManager stop_button(11, false);
 
+// Calibration for TV
+int cal[9] = {950, 1062, 1155, 1238, 1320, 1393, 1465, 1538, 1610};
+
 // Default settings
 VentSettings vs = {'X', 500, 12, 1, 3, 0, 00, 20, 0, 0, 0, false}; 
 
@@ -100,7 +103,10 @@ void transmit() {
   // Send settings to controller unit, if we're loading.
   if (vs.mode == 'L') {
       // TODO Build lookup table based on real information.
-      int setpoint = map(vs.tidal_volume, 300, 650, 887, 1610);
+      /*int setpoint = map(vs.tidal_volume, 300, 650, 887, 1610);*/
+      /*int setpoint = 1538;*/
+      /*int setpoint = tv_setpoint.valueAt(vs.tidal_volume);*/
+      int setpoint = cal[(vs.tidal_volume - 300)/50];
       Wire.write(byte(setpoint >> 8));
       Wire.write(byte(setpoint & 0x00FF));
       Wire.write(byte(vs.respiration_rate));


### PR DESCRIPTION
We manually calibrated the machine to deliver the correct tidal volume for the Ambu SPUR II bag! Each setpoint is as close as we could get it at RR=12, I:E=1:3. These settings are +- 10% of the displayed setting.